### PR TITLE
Update HelmExtension.java

### DIFF
--- a/helm/src/main/java/com/github/rmee/helm/HelmExtension.java
+++ b/helm/src/main/java/com/github/rmee/helm/HelmExtension.java
@@ -35,7 +35,7 @@ public class HelmExtension extends ClientExtensionBase {
 					return downloadFileName + "-linux-amd64.tar.gz";
 				}
 				else if (operatingSystem.isWindows()) {
-					return downloadFileName + "-windows-amd64.zip";
+					return downloadFileName + "-windows-amd64.tar.gz";
 				}
 				else if (operatingSystem.isMacOsX()) {
 					return downloadFileName + "-darwin-amd64.tar.gz";


### PR DESCRIPTION
There is no -windows-amd64.zip for some version of helm, e.g. helm-v2.7.2-windows-amd64.zip, only a -helm-v2.7.2-windows-amd64.tar.gz
 
