### PR TITLE
introduced generic cliExec task

### DIFF
--- a/az/src/main/java/com/github/rmee/az/AzExec.java
+++ b/az/src/main/java/com/github/rmee/az/AzExec.java
@@ -1,16 +1,12 @@
 package com.github.rmee.az;
 
 import com.github.rmee.cli.base.CliExecSpec;
-import com.github.rmee.cli.base.internal.ClientExecBase;
+import com.github.rmee.cli.base.internal.CliExecBase;
 import org.gradle.api.tasks.TaskAction;
 
-public class AzExec extends ClientExecBase {
+public class AzExec extends CliExecBase {
 
 	private AzExecSpec spec = new AzExecSpec();
-
-	public AzExec() {
-		setGroup("provision");
-	}
 
 	@TaskAction
 	public void run() {

--- a/az/src/main/java/com/github/rmee/az/AzPlugin.java
+++ b/az/src/main/java/com/github/rmee/az/AzPlugin.java
@@ -2,6 +2,7 @@ package com.github.rmee.az;
 
 import com.github.rmee.az.aks.AzGetKubernetesCredentialsTask;
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -9,35 +10,38 @@ import java.io.File;
 
 public class AzPlugin implements Plugin<Project> {
 
-    public void apply(Project project) {
-        File azureConfigDir = new File(project.getBuildDir(), ".azure");
+	public void apply(Project project) {
+		File azureConfigDir = new File(project.getBuildDir(), ".azure");
 
-        AzExtension extension = project.getExtensions().create("az", AzExtension.class);
-        extension.setProject(project);
-        // TODO azure-cli image insufficient by default: https://github.com/Azure/AKS/issues/469
-        //extension.getCli().setImageName("microsoft/azure-cli");
-        extension.getCli().setImageName("remmeier/azure-cli-kubectl");
-        extension.getCli().setVersion("2.0.38");
+		AzExtension extension = project.getExtensions().create("az", AzExtension.class);
+		extension.setProject(project);
+		// TODO azure-cli image insufficient by default: https://github.com/Azure/AKS/issues/469
+		//extension.getCli().setImageName("microsoft/azure-cli");
+		extension.getCli().setImageName("remmeier/azure-cli-kubectl");
+		extension.getCli().setVersion("2.0.38");
 
-        AzLoginTask login = project.getTasks().create("azLogin", AzLoginTask.class);
-        AzGetKubernetesCredentialsTask getCredentials =
-                project.getTasks().create("azGetKubernetesCredentials", AzGetKubernetesCredentialsTask.class);
-        getCredentials.dependsOn(login);
+		AzLoginTask login = project.getTasks().create("azLogin", AzLoginTask.class);
+		AzGetKubernetesCredentialsTask getCredentials =
+				project.getTasks().create("azGetKubernetesCredentials", AzGetKubernetesCredentialsTask.class);
+		getCredentials.dependsOn(login);
 
-        extension.setSubscriptionId(System.getenv("AZ_SUBSCRIPTION_ID"));
-        extension.setServicePrincipal(Boolean.parseBoolean(System.getenv("AZ_SERVICE_PRINCIPLE")));
-        extension.setUserName(System.getenv("AZ_USER"));
-        extension.setPassword(System.getenv("AZ_PASS"));
-        extension.setTenantId(System.getenv("AZ_TENANT_ID"));
-        extension.getAks().setKubeDir(new File(project.getRootProject().getProjectDir(), "build/.kube"));
+		extension.setSubscriptionId(System.getenv("AZ_SUBSCRIPTION_ID"));
+		extension.setServicePrincipal(Boolean.parseBoolean(System.getenv("AZ_SERVICE_PRINCIPLE")));
+		extension.setUserName(System.getenv("AZ_USER"));
+		extension.setPassword(System.getenv("AZ_PASS"));
+		extension.setTenantId(System.getenv("AZ_TENANT_ID"));
+		extension.getAks().setKubeDir(new File(project.getRootProject().getProjectDir(), "build/.kube"));
 
-        project.afterEvaluate(project1 -> {
-            Cli cli = extension.getCli();
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("az", extension.getCli());
 
-            cli.addDefaultMappings(project);
-            cli.setupWrapper(project);
-        });
-    }
+		project.afterEvaluate(project1 -> {
+			Cli cli = extension.getCli();
+
+			cli.addDefaultMappings(project);
+			cli.setupWrapper(project);
+		});
+	}
 }
 
 

--- a/cli-base/src/main/java/com/github/rmee/cli/base/CliExec.java
+++ b/cli-base/src/main/java/com/github/rmee/cli/base/CliExec.java
@@ -1,0 +1,22 @@
+package com.github.rmee.cli.base;
+
+import com.github.rmee.cli.base.internal.CliExecBase;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+public class CliExec extends CliExecBase {
+
+	private CliExecSpec spec = new CliExecSpec();
+
+	@TaskAction
+	public void exec() {
+		CliExecExtension extension = getProject().getExtensions().getByType(CliExecExtension.class);
+		extension.exec(spec);
+	}
+
+	@Override
+	@Input
+	protected CliExecSpec retrieveSpec() {
+		return spec;
+	}
+}

--- a/cli-base/src/main/java/com/github/rmee/cli/base/CliExecExtension.java
+++ b/cli-base/src/main/java/com/github/rmee/cli/base/CliExecExtension.java
@@ -1,4 +1,28 @@
 package com.github.rmee.cli.base;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class CliExecExtension {
+
+	private Map<String, Cli> clients = new HashMap<>();
+
+	public void register(String name, Cli cli) {
+		clients.put(name, cli);
+	}
+
+	public Map<String, Cli> getClients() {
+		return clients;
+	}
+
+	public void exec(CliExecSpec spec) {
+		String cliName = (String) spec.getCommandLine().get(0);
+
+		Cli cli = clients.get(cliName);
+		if (cli == null) {
+			throw new IllegalStateException("no CLI with name '" + cliName + "' registered");
+		}
+
+		cli.exec(spec);
+	}
 }

--- a/cli-base/src/main/java/com/github/rmee/cli/base/CliExecPlugin.java
+++ b/cli-base/src/main/java/com/github/rmee/cli/base/CliExecPlugin.java
@@ -5,11 +5,9 @@ import org.gradle.api.Project;
 
 public class CliExecPlugin implements Plugin<Project> {
 
-    public void apply(Project project) {
-        project.getPlugins().apply("de.undercouch.download");
-
-        CliExecExtension extension = project.getExtensions().create("cliExec", CliExecExtension.class);
-
-    }
+	public void apply(Project project) {
+		project.getPlugins().apply("de.undercouch.download");
+		project.getExtensions().create("cliExec", CliExecExtension.class);
+	}
 }
 

--- a/cli-base/src/main/java/com/github/rmee/cli/base/CliExecSpec.java
+++ b/cli-base/src/main/java/com/github/rmee/cli/base/CliExecSpec.java
@@ -6,10 +6,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
-public abstract class CliExecSpec<T extends CliExecSpec> {
+public class CliExecSpec<T extends CliExecSpec> {
 
-	private List<String> commandLine;
+	private Supplier<List<String>> commandLine;
 
 	private boolean ignoreExitValue = false;
 
@@ -55,20 +56,24 @@ public abstract class CliExecSpec<T extends CliExecSpec> {
 	}
 
 	public List<String> getCommandLine() {
-		return commandLine;
+		return commandLine.get();
 	}
 
 	public void setCommandLine(String commandLine) {
-		this.commandLine = Arrays.asList(commandLine.split("\\s+"));
+		this.commandLine = () -> Arrays.asList(commandLine.split("\\s+"));
+	}
+
+	public void setCommandLine(Supplier<String> commandLine) {
+		this.commandLine = () -> Arrays.asList(commandLine.get().split("\\s+"));
 	}
 
 	public void setCommandLine(List<String> commandLine) {
-		this.commandLine = commandLine;
+		this.commandLine = () -> commandLine;
 	}
 
 	public final T duplicate() {
 		CliExecSpec duplicate = newSpec();
-		duplicate.commandLine = new ArrayList(commandLine);
+		duplicate.commandLine = commandLine != null ? () -> new ArrayList(commandLine.get()) : null;
 		duplicate.outputFormat = outputFormat;
 		duplicate.ignoreExitValue = ignoreExitValue;
 		duplicate.volumesFrom = volumesFrom;

--- a/cli-base/src/main/java/com/github/rmee/cli/base/internal/CliExecBase.java
+++ b/cli-base/src/main/java/com/github/rmee/cli/base/internal/CliExecBase.java
@@ -1,14 +1,13 @@
 package com.github.rmee.cli.base.internal;
 
 import com.github.rmee.cli.base.CliExecSpec;
-import groovy.lang.Closure;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 
 import java.io.File;
 import java.util.List;
 
-public abstract class ClientExecBase extends DefaultTask {
+public abstract class CliExecBase extends DefaultTask {
 
 	@Input
 	public boolean isIgnoreExitValue() {
@@ -28,9 +27,6 @@ public abstract class ClientExecBase extends DefaultTask {
 
 	public void commandLine(String commandLine) {
 		retrieveSpec().setCommandLine(commandLine);
-	}
-
-	public void commandLine(Closure closure) {
 	}
 
 	public void commandLine(List<String> commandLine) {

--- a/gcloud/src/main/java/com/github/rmee/gcloud/GCloudExec.java
+++ b/gcloud/src/main/java/com/github/rmee/gcloud/GCloudExec.java
@@ -1,10 +1,10 @@
 package com.github.rmee.gcloud;
 
 import com.github.rmee.cli.base.CliExecSpec;
-import com.github.rmee.cli.base.internal.ClientExecBase;
+import com.github.rmee.cli.base.internal.CliExecBase;
 import org.gradle.api.tasks.TaskAction;
 
-public class GCloudExec extends ClientExecBase {
+public class GCloudExec extends CliExecBase {
 
 	private GCloudExecSpec spec = new GCloudExecSpec();
 

--- a/gcloud/src/main/java/com/github/rmee/gcloud/GCloudPlugin.java
+++ b/gcloud/src/main/java/com/github/rmee/gcloud/GCloudPlugin.java
@@ -1,6 +1,7 @@
 package com.github.rmee.gcloud;
 
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import com.github.rmee.cli.base.ClientExtensionBase;
 import com.github.rmee.gcloud.gke.GCloudGetKubernetesCredentialsTask;
 import org.gradle.api.Plugin;
@@ -11,41 +12,44 @@ import java.io.File;
 
 public class GCloudPlugin implements Plugin<Project> {
 
-    public void apply(Project project) {
-        File configDir = new File(project.getBuildDir(), ".gcloud");
+	public void apply(Project project) {
+		GCloudExtension extension = project.getExtensions().create("gcloud", GCloudExtension.class);
+		extension.initProject(project);
+		extension.getCli().getBinNames().add("gsutil");
+		extension.getCli().setImageName("google/cloud-sdk");
+		extension.getCli().setVersion("159.0.0");
 
-        GCloudExtension extension = project.getExtensions().create("gcloud", GCloudExtension.class);
-        extension.initProject(project);
-        extension.getCli().setImageName("google/cloud-sdk");
-        extension.getCli().setVersion("159.0.0");
+		GCloudActivateServiceAccountTask activateServiceAccount =
+				project.getTasks().create("gcloudActivateServiceAccount", GCloudActivateServiceAccountTask.class);
+		GCloudGetKubernetesCredentialsTask getCredentials =
+				project.getTasks().create("gcloudGetKubernetesCredentials", GCloudGetKubernetesCredentialsTask.class);
+		GCloudSetProjectTask setProject = project.getTasks().create("gcloudSetProject",
+				GCloudSetProjectTask.class);
 
-        GCloudActivateServiceAccountTask activateServiceAccount =
-                project.getTasks().create("gcloudActivateServiceAccount", GCloudActivateServiceAccountTask.class);
-        GCloudGetKubernetesCredentialsTask getCredentials =
-                project.getTasks().create("gcloudGetKubernetesCredentials", GCloudGetKubernetesCredentialsTask.class);
-        GCloudSetProjectTask setProject = project.getTasks().create("gcloudSetProject",
-                GCloudSetProjectTask.class);
-
-        getCredentials.dependsOn(setProject);
+		getCredentials.dependsOn(setProject);
 
 
-        extension.getGke().setKubeDir(new File(project.getRootProject().getProjectDir(), "build/.kube"));
+		extension.getGke().setKubeDir(new File(project.getRootProject().getProjectDir(), "build/.kube"));
 
-        project.afterEvaluate(project1 -> {
-            Cli cli = extension.getCli();
-            cli.addDefaultMappings(project);
-            cli.setupWrapper(project);
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("gcloud", extension.getCli());
+		cliExec.register("gsutil", extension.getCli());
 
-            // integrate with Kubernetes if available
-            try {
-                ClientExtensionBase kubectl = (ClientExtensionBase) project.getExtensions().getByName("kubectl");
-                Cli kubectlCli = kubectl.getCli();
-                kubectlCli.setImageName(cli.getImageName());
-                kubectlCli.setVersion(cli.getVersion());
-            } catch (UnknownDomainObjectException e) {
-            }
-        });
-    }
+		project.afterEvaluate(project1 -> {
+			Cli cli = extension.getCli();
+			cli.addDefaultMappings(project);
+			cli.setupWrapper(project);
+
+			// integrate with Kubernetes if available
+			try {
+				ClientExtensionBase kubectl = (ClientExtensionBase) project.getExtensions().getByName("kubectl");
+				Cli kubectlCli = kubectl.getCli();
+				kubectlCli.setImageName(cli.getImageName());
+				kubectlCli.setVersion(cli.getVersion());
+			} catch (UnknownDomainObjectException e) {
+			}
+		});
+	}
 }
 
 

--- a/helm/src/main/java/com/github/rmee/helm/HelmExec.java
+++ b/helm/src/main/java/com/github/rmee/helm/HelmExec.java
@@ -1,11 +1,11 @@
 package com.github.rmee.helm;
 
 import com.github.rmee.cli.base.CliExecSpec;
-import com.github.rmee.cli.base.internal.ClientExecBase;
+import com.github.rmee.cli.base.internal.CliExecBase;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
-public class HelmExec extends ClientExecBase {
+public class HelmExec extends CliExecBase {
 
 	private HelmExecSpec spec = new HelmExecSpec();
 

--- a/helm/src/main/java/com/github/rmee/helm/HelmPlugin.java
+++ b/helm/src/main/java/com/github/rmee/helm/HelmPlugin.java
@@ -1,6 +1,7 @@
 package com.github.rmee.helm;
 
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import com.github.rmee.cli.base.CliExecPlugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
@@ -35,6 +36,9 @@ public class HelmPlugin implements Plugin<Project> {
 
         helmPackages.setGroup("kubernetes");
         helmInit.dependsOn(helmBootstrap);
+
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("helm", extension.getCli());
 
         Set<String> packageNames = extension.getPackageNames();
         for (String packageName : packageNames) {

--- a/helm/src/test/java/com/github/rmee/helm/HelmPackageTest.java
+++ b/helm/src/test/java/com/github/rmee/helm/HelmPackageTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.internal.impldep.com.amazonaws.util.IOUtils;
 import org.gradle.internal.impldep.org.testng.Assert;
 import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -13,44 +14,57 @@ import java.nio.charset.StandardCharsets;
 
 public class HelmPackageTest {
 
-    private File workingDir;
+	private File workingDir;
 
-    @Test
-    public void testPackaging() throws IOException {
-        File tempDir = new File("build/tmp/helm");
-        tempDir.mkdirs();
+	@Before
+	public void setup() throws IOException {
+		File tempDir = new File("build/tmp/helm");
+		tempDir.mkdirs();
 
-        workingDir = new File(tempDir, "demo");
-        workingDir.mkdirs();
+		workingDir = new File(tempDir, "demo");
+		workingDir.mkdirs();
 
-        File chartFolder = new File(workingDir, "src/main/helm/helmapp");
-        File remplateFolder = new File(chartFolder, "templates");
-        remplateFolder.mkdirs();
+		File chartFolder = new File(workingDir, "src/main/helm/helmapp");
+		File remplateFolder = new File(chartFolder, "templates");
+		remplateFolder.mkdirs();
 
-        System.setProperty("org.gradle.daemon", "false");
+		System.setProperty("org.gradle.daemon", "false");
 
-        File gradleFile = new File(workingDir, "build.gradle");
-        File chartFile = new File(chartFolder, "Chart.yaml");
-        File valuesFile = new File(chartFolder, "values.yaml");
-        File serviceFile = new File(remplateFolder, "service.yaml");
+		File gradleFile = new File(workingDir, "build.gradle");
+		File chartFile = new File(chartFolder, "Chart.yaml");
+		File valuesFile = new File(chartFolder, "values.yaml");
+		File serviceFile = new File(remplateFolder, "service.yaml");
 
-        ClassLoader cl = getClass().getClassLoader();
-        Assert.assertNotNull(cl.getResource("plugin-under-test-metadata.properties"));
+		ClassLoader cl = getClass().getClassLoader();
+		Assert.assertNotNull(cl.getResource("plugin-under-test-metadata.properties"));
 
-        File settingsFile = new File(workingDir, "settings.gradle");
-        FileUtils.write(settingsFile, "", StandardCharsets.UTF_8);
-        IOUtils.copy(cl.getResourceAsStream("build.gradle"), new FileOutputStream(gradleFile));
-        IOUtils.copy(cl.getResourceAsStream("Chart.yaml"), new FileOutputStream(chartFile));
-        IOUtils.copy(cl.getResourceAsStream("values.yaml"), new FileOutputStream(valuesFile));
-        IOUtils.copy(cl.getResourceAsStream("service.yaml"), new FileOutputStream(serviceFile));
+		File settingsFile = new File(workingDir, "settings.gradle");
+		FileUtils.write(settingsFile, "", StandardCharsets.UTF_8);
+		IOUtils.copy(cl.getResourceAsStream("build.gradle"), new FileOutputStream(gradleFile));
+		IOUtils.copy(cl.getResourceAsStream("Chart.yaml"), new FileOutputStream(chartFile));
+		IOUtils.copy(cl.getResourceAsStream("values.yaml"), new FileOutputStream(valuesFile));
+		IOUtils.copy(cl.getResourceAsStream("service.yaml"), new FileOutputStream(serviceFile));
 
-        GradleRunner runner = GradleRunner.create();
-        runner = runner.forwardOutput();
-        runner = runner.withPluginClasspath();
-        runner = runner.withProjectDir(workingDir).withArguments("helmInit", "helmPackage", "--stacktrace").forwardOutput();
-        runner.build();
+	}
 
-        File helmFile = new File(workingDir, "build/helm/helmapp-0.1.0.tgz");
-        Assert.assertTrue(helmFile.exists());
-    }
+	@Test
+	public void testGenericExec() throws IOException {
+		GradleRunner runner = GradleRunner.create();
+		runner = runner.forwardOutput();
+		runner = runner.withPluginClasspath();
+		runner = runner.withProjectDir(workingDir).withArguments("testHelmGeneric", "--stacktrace").forwardOutput();
+		runner.build();
+	}
+
+	@Test
+	public void testPackaging() throws IOException {
+		GradleRunner runner = GradleRunner.create();
+		runner = runner.forwardOutput();
+		runner = runner.withPluginClasspath();
+		runner = runner.withProjectDir(workingDir).withArguments("helmInit", "helmPackage", "--stacktrace").forwardOutput();
+		runner.build();
+
+		File helmFile = new File(workingDir, "build/helm/helmapp-0.1.0.tgz");
+		Assert.assertTrue(helmFile.exists());
+	}
 }

--- a/helm/src/test/resources/build.gradle
+++ b/helm/src/test/resources/build.gradle
@@ -1,10 +1,16 @@
 plugins {
-    id 'helm'
+	id 'helm'
 }
 version = '0.1.0'
 repositories {
-    jcenter()
+	jcenter()
 }
 
 
 apply plugin: 'helm'
+
+
+import com.github.rmee.cli.base.CliExec
+task testHelmGeneric(type: CliExec) {
+	commandLine 'helm --help'
+}

--- a/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExecBase.java
+++ b/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExecBase.java
@@ -2,18 +2,16 @@ package com.github.rmee.kubectl;
 
 import com.github.rmee.cli.base.ExecResult;
 import com.github.rmee.cli.base.OutputFormat;
-import com.github.rmee.cli.base.internal.ClientExecBase;
+import com.github.rmee.cli.base.internal.CliExecBase;
 import org.gradle.api.tasks.Input;
 
-public class KubectlExecBase extends ClientExecBase {
+public class KubectlExecBase extends CliExecBase {
 
 	protected KubectlExecSpec spec;
 
 	protected ExecResult result;
 
 	public KubectlExecBase() {
-		setGroup("kubernetes");
-
 		spec = createSpec();
 	}
 

--- a/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExtension.java
+++ b/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExtension.java
@@ -8,53 +8,58 @@ import org.gradle.internal.os.OperatingSystem;
 
 public class KubectlExtension extends KubectlExtensionBase {
 
-    @Override
-    protected Cli createClient() {
-        Cli cli = new Cli(this, "kubectl", new CliDownloadStrategy() {
-            @Override
-            public String computeDownloadFileName(Cli cli) {
-                OperatingSystem operatingSystem = cli.getOperatingSystem();
-                if (operatingSystem.isWindows()) {
-                    return "kubectl.exe";
-                }
-                return "kubectl";
-            }
+	@Override
+	protected Cli createClient() {
+		Cli cli = new Cli(this, "kubectl", new CliDownloadStrategy() {
+			@Override
+			public String computeDownloadFileName(Cli cli) {
+				OperatingSystem operatingSystem = cli.getOperatingSystem();
+				if (operatingSystem.isWindows()) {
+					return "kubectl.exe";
+				}
+				return "kubectl";
+			}
 
-            @Override
-            public String computeDownloadUrl(Cli cli, String repository, String downloadFileName) {
-                String downloadUrl = repository;
-                if (!downloadUrl.endsWith("/")) {
-                    downloadUrl += "/";
-                }
-                downloadUrl += "v" + cli.getVersion() + "/bin/";
+			@Override
+			public String computeDownloadUrl(Cli cli, String repository, String downloadFileName) {
+				String downloadUrl = repository;
+				if (!downloadUrl.endsWith("/")) {
+					downloadUrl += "/";
+				}
+				downloadUrl += "v" + cli.getVersion() + "/bin/";
 
-                OperatingSystem operatingSystem = cli.getOperatingSystem();
-                if (operatingSystem.isLinux()) {
-                    return downloadUrl + "linux/amd64/" + downloadFileName;
-                } else if (operatingSystem.isWindows()) {
-                    return downloadUrl + "windows/amd64/" + downloadFileName;
-                } else if (operatingSystem.isMacOsX()) {
-                    return downloadUrl + "darwin/amd64/" + downloadFileName;
-                } else {
-                    throw new IllegalStateException("unknown operation system: " + operatingSystem.getName());
-                }
-            }
-        });
-        cli.setVersion("2.9.1");
-        cli.setImageName("dtzar/helm-kubectl");
-        cli.setRepository("https://storage.googleapis.com/kubernetes-release/release/");
-        cli.setDockerized(true);
-        return cli;
-    }
+				OperatingSystem operatingSystem = cli.getOperatingSystem();
+				if (operatingSystem.isLinux()) {
+					return downloadUrl + "linux/amd64/" + downloadFileName;
+				} else if (operatingSystem.isWindows()) {
+					return downloadUrl + "windows/amd64/" + downloadFileName;
+				} else if (operatingSystem.isMacOsX()) {
+					return downloadUrl + "darwin/amd64/" + downloadFileName;
+				} else {
+					throw new IllegalStateException("unknown operation system: " + operatingSystem.getName());
+				}
+			}
+		});
+		cli.setVersion("2.9.1");
+		cli.setImageName("dtzar/helm-kubectl");
+		cli.setRepository("https://storage.googleapis.com/kubernetes-release/release/");
+		cli.setDockerized(true);
+		return cli;
+	}
 
-    @Override
-    public ExecResult exec(KubectlExecSpec execSpec) {
-        return super.exec(execSpec);
-    }
+	@Override
+	protected String getBinName() {
+		return "kubectl";
+	}
 
-    public ExecResult exec(Closure<KubectlExecSpec> closure) {
-        KubectlExecSpec spec = new KubectlExecSpec();
-        project.configure(spec, closure);
-        return exec(spec);
-    }
+	@Override
+	public ExecResult exec(KubectlExecSpec execSpec) {
+		return super.exec(execSpec);
+	}
+
+	public ExecResult exec(Closure<KubectlExecSpec> closure) {
+		KubectlExecSpec spec = new KubectlExecSpec();
+		project.configure(spec, closure);
+		return exec(spec);
+	}
 }

--- a/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExtensionBase.java
+++ b/kubectl/src/main/java/com/github/rmee/kubectl/KubectlExtensionBase.java
@@ -70,14 +70,16 @@ public abstract class KubectlExtensionBase extends ClientExtensionBase {
 
 	public String getToken(String serviceAccount) {
 		KubectlExecSpec spec = new KubectlExecSpec();
-		spec.setCommandLine(cli.getBinName() + " describe serviceaccount " + serviceAccount);
+		spec.setCommandLine(getBinName() + " describe serviceaccount " + serviceAccount);
 		ExecResult result = exec(spec);
 		String tokenName = result.getProperty("tokens");
 
-		spec.setCommandLine(cli.getBinName() + " describe secret " + tokenName);
+		spec.setCommandLine(getBinName() + " describe secret " + tokenName);
 		result = exec(spec);
 		return result.getProperty("token");
 	}
+
+	protected abstract String getBinName();
 
 	public ExecResult exec(String command) {
 		KubectlExecSpec spec = new KubectlExecSpec();

--- a/kubectl/src/main/java/com/github/rmee/kubectl/KubectlPlugin.java
+++ b/kubectl/src/main/java/com/github/rmee/kubectl/KubectlPlugin.java
@@ -1,6 +1,7 @@
 package com.github.rmee.kubectl;
 
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import com.github.rmee.cli.base.CliExecPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -10,34 +11,37 @@ import java.io.File;
 public class KubectlPlugin implements Plugin<Project> {
 
 
-    public void apply(Project project) {
-        project.getPlugins().apply(CliExecPlugin.class);
+	public void apply(Project project) {
+		project.getPlugins().apply(CliExecPlugin.class);
 
-        KubectlExtension extension = project.getExtensions().create("kubectl", KubectlExtension.class);
-        extension.setProject(project);
-        extension.setNamespace("default");
+		KubectlExtension extension = project.getExtensions().create("kubectl", KubectlExtension.class);
+		extension.setProject(project);
+		extension.setNamespace("default");
 
-        KubectlBootstrap bootstrap = project.getTasks().create("kubectlBootstrap", KubectlBootstrap.class);
-        KubectlUseContext login = project.getTasks().create("kubectlUseContext", KubectlUseContext.class);
-        project.getTasks().create("kubectlStartProxy", KubectlStartProxyTask.class);
-        login.dependsOn(bootstrap);
+		KubectlBootstrap bootstrap = project.getTasks().create("kubectlBootstrap", KubectlBootstrap.class);
+		KubectlUseContext login = project.getTasks().create("kubectlUseContext", KubectlUseContext.class);
+		project.getTasks().create("kubectlStartProxy", KubectlStartProxyTask.class);
+		login.dependsOn(bootstrap);
 
-        project.afterEvaluate(project1 -> {
-            Cli cli = extension.getCli();
-            if (cli.isDockerized()) {
-                bootstrap.setEnabled(false);
-                cli.setupWrapper(project);
-                cli.addDefaultMappings(project);
-            } else if (cli.getDownload()) {
-                File downloadDir = cli.getDownloadDir();
-                downloadDir.mkdirs();
-                bootstrap.dest(downloadDir);
-                bootstrap.src(cli.getDownloadUrl());
-            } else {
-                bootstrap.setEnabled(false);
-            }
-        });
-    }
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("kubectl", extension.getCli());
+
+		project.afterEvaluate(project1 -> {
+			Cli cli = extension.getCli();
+			if (cli.isDockerized()) {
+				bootstrap.setEnabled(false);
+				cli.setupWrapper(project);
+				cli.addDefaultMappings(project);
+			} else if (cli.getDownload()) {
+				File downloadDir = cli.getDownloadDir();
+				downloadDir.mkdirs();
+				bootstrap.dest(downloadDir);
+				bootstrap.src(cli.getDownloadUrl());
+			} else {
+				bootstrap.setEnabled(false);
+			}
+		});
+	}
 }
 
 

--- a/oc/src/main/java/com/github/rmee/oc/OcExtension.java
+++ b/oc/src/main/java/com/github/rmee/oc/OcExtension.java
@@ -11,89 +11,94 @@ import org.gradle.internal.os.OperatingSystem;
 
 public class OcExtension extends KubectlExtensionBase {
 
-    @Override
-    protected Cli createClient() {
-        CliDownloadStrategy downloadStrategy = new CliDownloadStrategy() {
+	@Override
+	protected Cli createClient() {
+		CliDownloadStrategy downloadStrategy = new CliDownloadStrategy() {
 
-            @Override
-            public String computeDownloadFileName(Cli cli) {
-                OperatingSystem operatingSystem = cli.getOperatingSystem();
+			@Override
+			public String computeDownloadFileName(Cli cli) {
+				OperatingSystem operatingSystem = cli.getOperatingSystem();
 
-                String downloadFileName = "openshift-origin-client-tools-v" + cli.getVersion();
-                if (operatingSystem.isLinux()) {
-                    return downloadFileName + "-linux-64bit.tar.gz";
-                } else if (operatingSystem.isWindows()) {
-                    return downloadFileName + "-windows.zip";
-                } else if (operatingSystem.isMacOsX()) {
-                    return downloadFileName + "-mac.zip";
-                } else {
-                    throw new IllegalStateException("unknown operation system: " + operatingSystem.getName());
-                }
-            }
+				String downloadFileName = "openshift-origin-client-tools-v" + cli.getVersion();
+				if (operatingSystem.isLinux()) {
+					return downloadFileName + "-linux-64bit.tar.gz";
+				} else if (operatingSystem.isWindows()) {
+					return downloadFileName + "-windows.zip";
+				} else if (operatingSystem.isMacOsX()) {
+					return downloadFileName + "-mac.zip";
+				} else {
+					throw new IllegalStateException("unknown operation system: " + operatingSystem.getName());
+				}
+			}
 
-            @Override
-            public String computeDownloadUrl(Cli cli, String repository, String downloadFileName) {
-                String downloadUrl = repository;
-                if (!downloadUrl.endsWith("/")) {
-                    downloadUrl += "/";
-                }
+			@Override
+			public String computeDownloadUrl(Cli cli, String repository, String downloadFileName) {
+				String downloadUrl = repository;
+				if (!downloadUrl.endsWith("/")) {
+					downloadUrl += "/";
+				}
 
-                String version = cli.getVersion();
-                int sep = version.indexOf("-");
-                if (sep == -1) {
-                    throw new IllegalArgumentException("expected version " + version + " to be of format x.y.z-abcdefg");
-                }
-                String baseVersion = version.substring(0, sep);
-                downloadUrl += "v" + baseVersion + "/";
-                downloadUrl += downloadFileName;
-                return downloadUrl;
-            }
-        };
-        Cli cli = new Cli(this, "oc", downloadStrategy);
-        cli.setDockerized(true);
-        cli.setImageName("widerin/openshift-cli");
-        cli.setVersion("v3.11.0");
-        cli.setRepository("https://github.com/openshift/origin/releases/download/");
-        return cli;
-    }
+				String version = cli.getVersion();
+				int sep = version.indexOf("-");
+				if (sep == -1) {
+					throw new IllegalArgumentException("expected version " + version + " to be of format x.y.z-abcdefg");
+				}
+				String baseVersion = version.substring(0, sep);
+				downloadUrl += "v" + baseVersion + "/";
+				downloadUrl += downloadFileName;
+				return downloadUrl;
+			}
+		};
+		Cli cli = new Cli(this, "oc", downloadStrategy);
+		cli.setDockerized(true);
+		cli.setImageName("widerin/openshift-cli");
+		cli.setVersion("v3.11.0");
+		cli.setRepository("https://github.com/openshift/origin/releases/download/");
+		return cli;
+	}
 
-    @Override
-    protected ExecResult createResult(String output) {
-        return new OcExecResult(output);
-    }
+	@Override
+	protected String getBinName() {
+		return "oc";
+	}
 
-    protected Credentials getCredentialsWithoutInit() {
-        return credentials;
-    }
+	@Override
+	protected ExecResult createResult(String output) {
+		return new OcExecResult(output);
+	}
 
-    public String getProjectName() {
-        init();
-        return getNamespace();
-    }
+	protected Credentials getCredentialsWithoutInit() {
+		return credentials;
+	}
 
-    public void setProjectName(String projectName) {
-        setNamespace(projectName);
-    }
+	public String getProjectName() {
+		init();
+		return getNamespace();
+	}
 
-    @Override
-    public OcExecResult exec(String command) {
-        OcExecSpec spec = new OcExecSpec();
-        spec.setCommandLine(command);
-        return exec(spec);
-    }
+	public void setProjectName(String projectName) {
+		setNamespace(projectName);
+	}
 
-    public OcExecResult exec(OcExecSpec spec) {
-        return (OcExecResult) super.exec(spec);
-    }
+	@Override
+	public OcExecResult exec(String command) {
+		OcExecSpec spec = new OcExecSpec();
+		spec.setCommandLine(command);
+		return exec(spec);
+	}
 
-    @Override
-    protected void setProject(Project project) {
-        super.setProject(project);
-    }
+	public OcExecResult exec(OcExecSpec spec) {
+		return (OcExecResult) super.exec(spec);
+	}
 
-    public OcExecResult exec(Closure<OcExecSpec> closure) {
-        OcExecSpec spec = new OcExecSpec();
-        project.configure(spec, closure);
-        return exec(spec);
-    }
+	@Override
+	protected void setProject(Project project) {
+		super.setProject(project);
+	}
+
+	public OcExecResult exec(Closure<OcExecSpec> closure) {
+		OcExecSpec spec = new OcExecSpec();
+		project.configure(spec, closure);
+		return exec(spec);
+	}
 }

--- a/oc/src/main/java/com/github/rmee/oc/OcPlugin.java
+++ b/oc/src/main/java/com/github/rmee/oc/OcPlugin.java
@@ -1,6 +1,7 @@
 package com.github.rmee.oc;
 
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import com.github.rmee.cli.base.CliExecPlugin;
 import com.github.rmee.cli.base.Credentials;
 import org.gradle.api.Plugin;
@@ -8,49 +9,52 @@ import org.gradle.api.Project;
 
 public class OcPlugin implements Plugin<Project> {
 
-    protected static final String CONTAINER_SOURCES_DIR = "/src";
+	protected static final String CONTAINER_SOURCES_DIR = "/src";
 
-    public void apply(Project project) {
-        project.getPlugins().apply(CliExecPlugin.class);
+	public void apply(Project project) {
+		project.getPlugins().apply(CliExecPlugin.class);
 
-        OcExtension extension = project.getExtensions().create("oc", OcExtension.class);
-        extension.setProject(project);
-        // extension.setKubeConfig(KubernetesUtils.getDefaultKubeConfig(project));
-        extension.setUrl(getVariable(project, "OPENSHIFT_URL"));
-        Credentials credentials = extension.getCredentialsWithoutInit();
-        credentials.setUserName(getVariable(project, "OPENSHIFT_USER"));
-        credentials.setPassword(getVariable(project, "OPENSHIFT_PASS"));
-        credentials.setToken(getVariable(project, "OPENSHIFT_TOKEN"));
+		OcExtension extension = project.getExtensions().create("oc", OcExtension.class);
+		extension.setProject(project);
+		// extension.setKubeConfig(KubernetesUtils.getDefaultKubeConfig(project));
+		extension.setUrl(getVariable(project, "OPENSHIFT_URL"));
+		Credentials credentials = extension.getCredentialsWithoutInit();
+		credentials.setUserName(getVariable(project, "OPENSHIFT_USER"));
+		credentials.setPassword(getVariable(project, "OPENSHIFT_PASS"));
+		credentials.setToken(getVariable(project, "OPENSHIFT_TOKEN"));
 
-        OcBootstrap ocBootstrap = project.getTasks().create("ocBootstrap", OcBootstrap.class);
-        OcLogin ocLogin = project.getTasks().create("ocLogin", OcLogin.class);
-        OcSetProject ocSetProject = project.getTasks().create("ocSetProject", OcSetProject.class);
-        OcNewProject ocNewProject = project.getTasks().create("ocNewProject", OcNewProject.class);
+		OcBootstrap ocBootstrap = project.getTasks().create("ocBootstrap", OcBootstrap.class);
+		OcLogin ocLogin = project.getTasks().create("ocLogin", OcLogin.class);
+		OcSetProject ocSetProject = project.getTasks().create("ocSetProject", OcSetProject.class);
+		OcNewProject ocNewProject = project.getTasks().create("ocNewProject", OcNewProject.class);
 
-        ocLogin.dependsOn(ocBootstrap);
-        ocNewProject.dependsOn(ocLogin);
-        ocSetProject.dependsOn(ocLogin);
-        ocSetProject.mustRunAfter(ocNewProject);
+		ocLogin.dependsOn(ocBootstrap);
+		ocNewProject.dependsOn(ocLogin);
+		ocSetProject.dependsOn(ocLogin);
+		ocSetProject.mustRunAfter(ocNewProject);
 
-        project.afterEvaluate(project1 -> {
-            Cli cli = extension.getCli();
-            if (cli.isDockerized()) {
-                ocBootstrap.setEnabled(false);
-                cli.setupWrapper(project);
-                cli.addDefaultMappings(project);
-            } else if (cli.getDownload()) {
-                ocBootstrap.dest(cli.getDownloadDir());
-                ocBootstrap.src(cli.getDownloadUrl());
-            } else {
-                ocBootstrap.setEnabled(false);
-            }
-        });
-    }
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("oc", extension.getCli());
 
-    private String getVariable(Project project, String key) {
-        String value = System.getenv(key);
-        return value != null ? value : (String) project.getProperties().get(key);
-    }
+		project.afterEvaluate(project1 -> {
+			Cli cli = extension.getCli();
+			if (cli.isDockerized()) {
+				ocBootstrap.setEnabled(false);
+				cli.setupWrapper(project);
+				cli.addDefaultMappings(project);
+			} else if (cli.getDownload()) {
+				ocBootstrap.dest(cli.getDownloadDir());
+				ocBootstrap.src(cli.getDownloadUrl());
+			} else {
+				ocBootstrap.setEnabled(false);
+			}
+		});
+	}
+
+	private String getVariable(Project project, String key) {
+		String value = System.getenv(key);
+		return value != null ? value : (String) project.getProperties().get(key);
+	}
 }
 
 

--- a/terraform/src/main/java/com/github/rmee/terraform/TerraformExec.java
+++ b/terraform/src/main/java/com/github/rmee/terraform/TerraformExec.java
@@ -1,18 +1,14 @@
 package com.github.rmee.terraform;
 
-import com.github.rmee.cli.base.internal.ClientExecBase;
+import com.github.rmee.cli.base.internal.CliExecBase;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
-public class TerraformExec extends ClientExecBase {
+public class TerraformExec extends CliExecBase {
 
 	public static final String CONTAINER_WORKING_DIRECTORY = ".terraform";
 
 	private TerraformExecSpec spec = new TerraformExecSpec();
-
-	public TerraformExec() {
-		setGroup("provision");
-	}
 
 	@TaskAction
 	public void exec() {

--- a/terraform/src/main/java/com/github/rmee/terraform/TerraformPlugin.java
+++ b/terraform/src/main/java/com/github/rmee/terraform/TerraformPlugin.java
@@ -1,6 +1,7 @@
 package com.github.rmee.terraform;
 
 import com.github.rmee.cli.base.Cli;
+import com.github.rmee.cli.base.CliExecExtension;
 import com.github.rmee.cli.base.CliExecPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -34,6 +35,9 @@ public class TerraformPlugin implements Plugin<Project> {
 		planTask.dependsOn(validateTask);
 		applyTask.dependsOn(planTask);
 		destroyTask.dependsOn(planTask);
+
+		CliExecExtension cliExec = project.getExtensions().getByType(CliExecExtension.class);
+		cliExec.register("terraform", extension.getCli());
 
 		project.afterEvaluate(project1 -> {
 			Cli cli = extension.getCli();


### PR DESCRIPTION
all plugins register there binary to CliExecExtension. CliExec task subsequently is able to transparently make use of all the plugins from a single task.
No longer necessary to make use of GCloudExec, TerraformExec, etc. as long as plugin specific features are accessed (which should hold for most use cases).