### PR TITLE
Convenience method to fetch Temurin's OpenJDK

### DIFF
--- a/jdk-bootstrap/src/main/java/com/github/rmee/jdk/bootstrap/JdkBootstrapExtension.java
+++ b/jdk-bootstrap/src/main/java/com/github/rmee/jdk/bootstrap/JdkBootstrapExtension.java
@@ -76,6 +76,12 @@ public class JdkBootstrapExtension {
 		this.version = version;
 	}
 
+	public void useTemurinOpenJdk(String version) {
+		String major = version.split("\\.", 2)[0];
+		urlTemplate = "https://github.com/adoptium/temurin" + major + "-binaries/releases/download/jdk-" + version +
+				"/OpenJDK" + major + "U-jdk_x64_${os}_hotspot_" + version.replace("+", "_") + ".${suffix}";
+		this.version = version;
+	}
 
 	public String getVersion() {
 		return version;


### PR DESCRIPTION
AdoptOpenJDK moved, so if convenience methods are still useful, Temurin's is probably the one people are going to want.