### PR TITLE
Also patch gradlew.bat

### DIFF
--- a/jdk-bootstrap/src/main/resources/bootstrap.bat.template
+++ b/jdk-bootstrap/src/main/resources/bootstrap.bat.template
@@ -1,0 +1,35 @@
+
+set JDK_DOWNLOAD_URL=${JDK_DOWNLOAD_URL_TEMPLATE}
+set JDK_DOWNLOAD_URL=%JDK_DOWNLOAD_URL:JDK_OS=windows%
+set JDK_DOWNLOAD_URL=%JDK_DOWNLOAD_URL:JDK_DIST_SUFFIX=zip%
+set JDK_VERSION=${JDK_VERSION_TEMPLATE}
+
+set JDK_CACHE_DIR=%USERPROFILE%\.gradle\jdk
+
+set JAVA_HOME=%JDK_CACHE_DIR%\jdk-%JDK_VERSION%
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
+set JDK_DOWNLOAD_FILE=%JDK_CACHE_DIR%\jdk-%JDK_VERSION%.zip
+
+if not exist %JAVA_HOME% (
+  if not exist %JDK_CACHE_DIR% (
+    mkdir %JDK_CACHE_DIR%
+    if %ERRORLEVEL% NEQ 0 (
+      echo gradlew: Fatal error creating local cache directory: %JDK_CACHE_DIR%
+      exit /B %ERRORLEVEL%
+    )
+  )
+
+  PowerShell -NonInteractive -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri \"%JDK_DOWNLOAD_URL%\" -OutFile \"%JDK_DOWNLOAD_FILE%\""
+  if %ERRORLEVEL% NEQ 0 (
+    echo gradlew: Fatal error downloading JDK from URL: %JDK_DOWNLOAD_URL%
+    exit /B %ERRORLEVEL%
+  )
+
+  PowerShell -NonInteractive -Command "$ProgressPreference='SilentlyContinue'; Expand-Archive -Path \"%JDK_DOWNLOAD_FILE%\" -DestinationPath \"%JDK_CACHE_DIR%\\\""
+  if %ERRORLEVEL% NEQ 0 (
+    echo gradlew: Fatal error expanding downloaded archive: %JDK_DOWNLOAD_FILE%
+    exit /B %ERRORLEVEL%
+  )
+
+  echo Installed JDK from %JDK_DOWNLOAD_URL% into %JAVA_HOME%
+)


### PR DESCRIPTION
Windows devs now get to benefit from this as well.

How it was done:
* Batch file template similar to the one for shell scripts
* PowerShell is run to do both the HTTP download and the extraction
* Newlines are corrected after the script is patched because in all likelihood the template file will not have the right line endings
* JDK_OS and similar values are left alone for the script itself to correct - the script has an easy time of this because it knows that the OS is windows and the suffix is zip.

Caveats:
* Still exhibits the issue mentioned in #35, consistent with the UNIX one.

